### PR TITLE
Fix memory leak caused by not unmounting the component

### DIFF
--- a/controls/pcfcontroldemo/MultiSelectControl/index.ts
+++ b/controls/pcfcontroldemo/MultiSelectControl/index.ts
@@ -164,5 +164,6 @@ export class MultiSelectPCFControl implements ComponentFramework.StandardControl
 	 * i.e. cancelling any pending remote calls, removing listeners, etc.
 	 */
 	public destroy(): void {
+		ReactDOM.unmountComponentAtNode(this._container);
 	}
 }


### PR DESCRIPTION
This change fixes a memory leak when the control is used in a multi session app e.g. the D365 Customer Service Workspace.